### PR TITLE
Refactor/ added text alternatives for non-text content

### DIFF
--- a/frontend/src/components/challenges/RecyclingProgressVisualization.tsx
+++ b/frontend/src/components/challenges/RecyclingProgressVisualization.tsx
@@ -24,21 +24,25 @@ export default function RecyclingProgressVisualization({
   const clampedProgress = useMemo(() => Math.max(0, Math.min(100, progress)), [progress]);
 
   return (
-    <div 
+    <div
       className={`relative overflow-hidden rounded-lg ${className}`}
       style={{ width, height }}
+      role="group"
+      aria-label={`Recycling progress ${clampedProgress.toFixed(0)} percent`}
     >
       {/* Background dirty image */}
       <img
         src={progressDirtyImage}
-        alt="Dirty state"
+        alt=""
+        aria-hidden="true"
         className="absolute inset-0 w-full h-full object-cover"
       />
       
       {/* Clean image with progressive reveal */}
       <img
         src={progressCleanImage}
-        alt="Clean state"
+        alt=""
+        aria-hidden="true"
         className="absolute inset-0 w-full h-full object-cover"
         style={{ 
           clipPath: `inset(0 ${100 - clampedProgress}% 0 0)`
@@ -50,12 +54,14 @@ export default function RecyclingProgressVisualization({
         <div
           className="absolute top-0 bottom-0 w-0.5 bg-white/80 shadow-lg"
           style={{ left: `${clampedProgress}%` }}
+          aria-hidden="true"
         >
           {/* Animated recycling icon */}
           <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-8 h-8 bg-white/90 rounded-full shadow-lg flex items-center justify-center">
             <img 
               src={recycleGif}
-              alt="Recycling animation"
+              alt=""
+              aria-hidden="true"
               className="w-8 h-8 object-contain"
             />
           </div>

--- a/frontend/src/components/common/navbar.tsx
+++ b/frontend/src/components/common/navbar.tsx
@@ -37,7 +37,11 @@ export default function Navbar({ className }: NavbarProps) {
     <nav className={`bg-[#b07f5a]/90 backdrop-blur-sm text-white px-3 py-2 flex items-center gap-2 h-16 rounded-full shadow-lg border border-white/20 max-w-4xl mx-auto ${className || ''}`}>
       {/* Logo and Title */}
       <div className="flex items-center shrink-0">
-        <img src={logo} alt="Wasteless Logo" className="h-23 w-auto" />
+        <img
+          src={logo}
+          alt={t ? t('navbar.logoAlt', 'WasteLess application logo') : 'WasteLess application logo'}
+          className="h-23 w-auto"
+        />
       </div>
 
       {/* Navigation Links */}

--- a/frontend/src/components/feedpage/comment-item.tsx
+++ b/frontend/src/components/feedpage/comment-item.tsx
@@ -108,7 +108,15 @@ export default function CommentItem({ comment, onUpdate, onDelete, className }: 
   return (
     <div className={cn("flex gap-3 py-2 group", className)}>
       <Avatar className="w-8 h-8 shrink-0">
-        <AvatarImage src={userAvatar} alt={commentUsername || 'User'} />
+        <AvatarImage
+          src={userAvatar}
+          alt={commentUsername
+            ? t('profile.photoAlt', {
+                username: commentUsername,
+                defaultValue: `${commentUsername}'s profile photo`,
+              })
+            : t('profile.photoAltAnon', 'Profile photo')}
+        />
         <AvatarFallback className="bg-primary text-primary-foreground text-xs">
           {(commentUsername || 'U').charAt(0).toUpperCase()}
         </AvatarFallback>

--- a/frontend/src/components/feedpage/comment-section.tsx
+++ b/frontend/src/components/feedpage/comment-section.tsx
@@ -104,7 +104,7 @@ export default function CommentSection({ postId, onCommentAdded }: CommentSectio
         <form onSubmit={handleSubmitComment} className="p-4 border-t">
           <div className="flex items-center gap-3">
             <Avatar className="w-8 h-8 shrink-0">
-              <AvatarImage src={userAvatar} alt={currentUser} />
+              <AvatarImage src={userAvatar} alt={t('profile.photoAlt', { username: currentUser, defaultValue: `${currentUser}'s profile photo` })} />
               <AvatarFallback className="bg-primary text-primary-foreground text-xs">
                 {currentUser.charAt(0).toUpperCase()}
               </AvatarFallback>
@@ -122,6 +122,8 @@ export default function CommentSection({ postId, onCommentAdded }: CommentSectio
                 type="submit"
                 size="icon"
                 disabled={!newComment.trim() || isSubmitting}
+                aria-label={t('comment.send', 'Send comment')}
+                title={t('comment.send', 'Send comment')}
               >
                 <Send className="h-4 w-4" />
               </Button>

--- a/frontend/src/components/feedpage/post-card.tsx
+++ b/frontend/src/components/feedpage/post-card.tsx
@@ -166,7 +166,7 @@ export default function PostCard({ post, onPostUpdate, onPostDelete, className }
         <div className="w-full aspect-square relative overflow-hidden">
           <img
             src={post.photoUrl}
-            alt={t('post.imageAlt')}
+            alt={t('post.imageAlt', { username: post.creatorUsername, defaultValue: `${post.creatorUsername}'s post image` })}
             className="w-full h-full object-cover"
             loading="lazy"
           />
@@ -178,7 +178,15 @@ export default function PostCard({ post, onPostUpdate, onPostDelete, className }
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <Avatar className="w-6 h-6">
-              <AvatarImage src={userAvatar} alt={post.creatorUsername} />
+              <AvatarImage
+                src={userAvatar}
+                alt={post.creatorUsername
+                  ? t('profile.photoAlt', {
+                      username: post.creatorUsername,
+                      defaultValue: `${post.creatorUsername}'s profile photo`,
+                    })
+                  : t('profile.photoAltAnon', 'Profile photo')}
+              />
               <AvatarFallback className="bg-primary text-primary-foreground text-xs">
                 {post.creatorUsername.charAt(0).toUpperCase()}
               </AvatarFallback>

--- a/frontend/src/components/profile/edit_profile.tsx
+++ b/frontend/src/components/profile/edit_profile.tsx
@@ -84,14 +84,18 @@ export default function EditProfile({ username, initialBio, initialPhotoUrl, onB
                     aria-label={t('profile.changePhoto')}
                 >
                     {photoUrl ? (
-                        <img src={photoUrl} alt="Profile" className="w-full h-full object-cover" />
+                        <img
+                            src={photoUrl}
+                            alt={storedUsername ? t('profile.photoAlt', { username: storedUsername, defaultValue: `${storedUsername}'s profile photo` }) : t('profile.photoAltAnon', 'Profile photo')}
+                            className="w-full h-full object-cover"
+                        />
                     ) : (
                         <div className="w-full h-full grid place-items-center text-muted-foreground">{t('profile.noPhoto', 'No photo')}</div>
                     )}
                     <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
                         <div className="flex items-center gap-2 text-white text-sm">
                             {/* Pencil icon */}
-                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                            <svg aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                                 <path d="M12 20h9" />
                                 <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z" />
                             </svg>

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -9,6 +9,9 @@
         "welcomeMessage": "Welcome to Our Website!",
         "description": "We are glad to have you here. Explore our features and enjoy your stay!"
     },
+    "navbar": {
+        "logoAlt": "WasteLess application logo"
+    },
     "login": {
         "title": "Login to your account",
         "description": "Enter your email below to login to your account",
@@ -62,7 +65,10 @@
         "changePhoto": "Change Photo",
         "delete": "Delete Account",
         "confirmDelete": "This will permanently delete your account. Continue?",
-        "deleting": "Deleting..."
+        "deleting": "Deleting...",
+        "photoAlt": "{{username}}'s profile photo",
+        "photoAltAnon": "Profile photo",
+        "editImage": "Edit Image"
     },
     "main": {
         "navbar": "Main"
@@ -181,7 +187,7 @@
         }
     },
     "post": {
-        "imageAlt": "Post image",
+        "imageAlt": "{{username}}'s post image",
         "likes": "{{count}} like",
         "likes_plural": "{{count}} likes",
         "viewComments": "View {{count}} comment",
@@ -225,7 +231,8 @@
             "minutes": "{{count}}m", 
             "hours": "{{count}}h",
             "days": "{{count}}d"
-        }
+        },
+        "send": "Send comment"
     },
     "search": {
         "placeholder": "Search posts...",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -9,6 +9,9 @@
         "welcomeMessage": "Web Sitemize Hoş Geldiniz!",
         "description": "Burada olduğunuz için mutluyuz. Özelliklerimizi keşfedin ve keyfini çıkarın!"
     },
+    "navbar": {
+        "logoAlt": "WasteLess uygulama logosu"
+    },
     "login": {
         "title": "Hesabınıza giriş yapın",
         "description": "Hesabınıza giriş yapmak için lütfen e-posta adresinizi girin",
@@ -62,7 +65,10 @@
         "changePhoto": "Fotoğrafı Değiştir",
         "delete": "Hesabı Sil",
         "confirmDelete": "Bu işlem hesabınızı kalıcı olarak silecek. Devam edilsin mi?",
-        "deleting": "Siliniyor..."
+        "deleting": "Siliniyor...",
+        "photoAlt": "{{username}}'in profil fotoğrafı",
+        "photoAltAnon": "Profil fotoğrafı",
+        "editImage": "Resmi Düzenle"
     },
     "main" : {
         "navbar": "Ana Sayfa"
@@ -169,7 +175,7 @@
         }
     },
     "post": {
-        "imageAlt": "Gönderi resmi",
+        "imageAlt": "{{username}}'in gönderi resmi",
         "likes": "{{count}} beğeni",
         "viewComments": "{{count}} yorumu görüntüle",
         "hideComments": "Yorumları gizle",
@@ -211,7 +217,8 @@
             "minutes": "{{count}}dk",
             "hours": "{{count}}sa",
             "days": "{{count}}g"
-        }
+        },
+        "send": "Yorumu Gönder"
     },
     "search": {
         "placeholder": "Gönderi ara...",

--- a/frontend/src/routes/profile/_index.tsx
+++ b/frontend/src/routes/profile/_index.tsx
@@ -133,7 +133,11 @@ export default function ProfileIndex() {
             <div className="flex flex-col items-center text-center gap-4">
               <div className="w-28 h-28 rounded-full overflow-hidden bg-muted border border-border">
                 {photoUrl ? (
-                  <img src={photoUrl} alt="Profile" className="w-full h-full object-cover" />
+                  <img
+                    src={photoUrl}
+                    alt={username ? t('profile.photoAlt', { username, defaultValue: `${username}'s profile photo` }) : t('profile.photoAltAnon', 'Profile photo')}
+                    className="w-full h-full object-cover"
+                  />
                 ) : (
                   <div className="w-full h-full grid place-items-center text-muted-foreground">{t('profile.noPhoto', 'No photo')}</div>
                 )}


### PR DESCRIPTION
The whole frontend code is revised and added text alternatives for non-text content with their corresponding translations in the translation files. Non-text content whose text alternatives were added:

- profile photo in profile page
- profile photo in edit profile page
- application logo in the nabber
- post image
- profile photo in the post
- profile photo in comment section
- profile photo in comment item
- send button in comment section

Additionally, I removed text alternatives for "Recycling Progress Visualization" images since they convey no information to the user, just for aesthetics.