### PR TITLE
enhance notifications with profile dialog integration

### DIFF
--- a/frontend/src/components/profile/userProfileDialog.tsx
+++ b/frontend/src/components/profile/userProfileDialog.tsx
@@ -135,7 +135,7 @@ export default function UserProfileDialog({ username, open, onOpenChange, onUser
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-4xl flex flex-col">
+      <DialogContent className="sm:max-w-[50rem] flex flex-col">
         <DialogHeader>
           <DialogTitle>
             {username ? t('profile.userProfileTitle', { username }) : t('profile.userProfile')}

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -341,6 +341,9 @@
             "follow": "{{actor}} started following you",
             "mention": "{{actor}} mentioned you in a {{objectType}}",
             "default": "{{actor}} {{type}}"
-        }
+        },
+        "likedYourPost_suffix": "liked your post",
+        "commentedOnYourPost_suffix": "commented on your post",
+        "startedFollowing_suffix": "started following you"
     }
 }

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -335,6 +335,9 @@
             "follow": "{{actor}} sizi takip etmeye başladı",
             "mention": "{{actor}} sizi bir {{objectType}} bahsetti",
             "default": "{{actor}} {{type}}"
-        }
+        },
+        "likedYourPost_suffix": "gönderinizi beğendi",
+        "commentedOnYourPost_suffix": "gönderinize yorum yaptı",
+        "startedFollowing_suffix": "sizi takip etmeye başladı"
     }
 }


### PR DESCRIPTION
- Add profile dialog for follow notifications
- Make usernames clickable in notification dialog headers
- Add user avatars to notification detail dialog headers
- Adjust profile dialog width to max-w-[50rem]
- Hide notification dialog when profile dialog opens (preserves state)
- Pass onUsernameClick handler to PostCard and UserProfileDialog
- Add translation keys for clickable username notifications (en/tr)
- Style username as bold with hover underline for better UX
- Notification dialog hides but doesn't close when navigating to profiles