### PR TITLE
feat: add comprehensive screen reader accessibility support

### DIFF
--- a/frontend/src/components/feedpage/comment-item.tsx
+++ b/frontend/src/components/feedpage/comment-item.tsx
@@ -155,13 +155,21 @@ export default function CommentItem({ comment, onUpdate, onDelete, onUsernameCli
         ) : (
           <>
             <div className="bg-gray-100 rounded-lg px-3 py-2">
-              <button
-                type="button"
+              <div
+                role="link"
+                tabIndex={0}
                 onClick={() => commentUsername && onUsernameClick?.(commentUsername)}
-                className="block text-sm font-medium text-gray-900 mb-1 hover:underline text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    commentUsername && onUsernameClick?.(commentUsername);
+                  }
+                }}
+                className="block text-sm font-medium text-gray-900 mb-1 hover:underline text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded cursor-pointer"
+                aria-label={t('profile.userLabel', { username: commentUsername, defaultValue: `User ${commentUsername}` })}
               >
                 {commentUsername}
-              </button>
+              </div>
               <p className="text-sm text-gray-700 break-words">
                 {comment.content}
               </p>
@@ -181,6 +189,7 @@ export default function CommentItem({ comment, onUpdate, onDelete, onUsernameCli
                     size="icon"
                     onClick={handleEdit}
                     className="h-5 w-5 hover:bg-blue-50 hover:text-blue-600"
+                    aria-label={t('comment.edit', 'Edit comment')}
                   >
                     <Edit3 className="h-2.5 w-2.5" />
                   </Button>
@@ -189,6 +198,7 @@ export default function CommentItem({ comment, onUpdate, onDelete, onUsernameCli
                     size="icon"
                     onClick={() => setShowDeleteDialog(true)}
                     className="h-5 w-5 hover:bg-red-50 hover:text-red-600"
+                    aria-label={t('comment.delete', 'Delete comment')}
                   >
                     <Trash2 className="h-2.5 w-2.5" />
                   </Button>
@@ -203,9 +213,9 @@ export default function CommentItem({ comment, onUpdate, onDelete, onUsernameCli
       <Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
-            <DialogTitle>{t('comment.delete.title')}</DialogTitle>
+            <DialogTitle>{t('comment.deleteDialog.title')}</DialogTitle>
             <DialogDescription>
-              {t('comment.delete.description')}
+              {t('comment.deleteDialog.description')}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter className="flex gap-2 sm:justify-end">
@@ -214,14 +224,14 @@ export default function CommentItem({ comment, onUpdate, onDelete, onUsernameCli
               onClick={() => setShowDeleteDialog(false)}
               disabled={isLoading}
             >
-              {t('comment.delete.cancel')}
+              {t('comment.deleteDialog.cancel')}
             </Button>
             <Button
               variant="destructive"
               onClick={handleDeleteComment}
               disabled={isLoading}
             >
-              {isLoading ? t('comment.delete.deleting') : t('comment.delete.confirm')}
+              {isLoading ? t('comment.deleteDialog.deleting') : t('comment.deleteDialog.confirm')}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/frontend/src/components/feedpage/edit-post-dialog.tsx
+++ b/frontend/src/components/feedpage/edit-post-dialog.tsx
@@ -81,6 +81,7 @@ export default function EditPostDialog({ post, onPostUpdated, currentUsername }:
           variant="ghost"
           size="icon"
           className="hover:bg-blue-50 hover:text-blue-600 transition-colors h-8 w-8"
+          aria-label={t('post.edit.button', 'Edit post')}
         >
           <Edit className="h-4 w-4" />
         </Button>

--- a/frontend/src/components/feedpage/image-dialog.tsx
+++ b/frontend/src/components/feedpage/image-dialog.tsx
@@ -43,6 +43,7 @@ export default function ImageDialog({
             size="icon"
             onClick={() => onOpenChange(false)}
             className="bg-black/50 hover:bg-destructive text-white rounded-full"
+            aria-label={t('post.closeImage', 'Close image')}
           >
             <X className="h-4 w-4" />
           </Button>

--- a/frontend/src/components/feedpage/post-card.tsx
+++ b/frontend/src/components/feedpage/post-card.tsx
@@ -207,13 +207,21 @@ export default function PostCard({ post, onPostUpdate, onPostDelete, onUsernameC
                 {post.creatorUsername.charAt(0).toUpperCase()}
               </AvatarFallback>
             </Avatar>
-            <button
-              type="button"
+            <div
+              role="link"
+              tabIndex={0}
               onClick={() => onUsernameClick?.(post.creatorUsername)}
-              className="font-semibold text-sm hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded"
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  onUsernameClick?.(post.creatorUsername);
+                }
+              }}
+              className="font-semibold text-sm hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded cursor-pointer"
+              aria-label={t('profile.userLabel', { username: post.creatorUsername, defaultValue: `User ${post.creatorUsername}` })}
             >
               {post.creatorUsername}
-            </button>
+            </div>
           </div>
           <div className="text-right">
             <p className="text-xs text-muted-foreground">{date}</p>
@@ -237,6 +245,7 @@ export default function PostCard({ post, onPostUpdate, onPostDelete, onUsernameC
               "hover:bg-red-50 hover:text-red-500 transition-colors h-8 w-8",
               isLiked && "text-red-500"
             )}
+            aria-label={isLiked ? t('post.unlike', 'Unlike post') : t('post.like', 'Like post')}
           >
             <Heart className={cn("h-4 w-4", isLiked && "fill-current")} />
           </Button>
@@ -245,6 +254,7 @@ export default function PostCard({ post, onPostUpdate, onPostDelete, onUsernameC
             size="icon"
             onClick={() => setShowComments(!showComments)}
             className="hover:bg-blue-50 hover:text-blue-500 transition-colors h-8 w-8"
+            aria-label={showComments ? t('post.hideComments', 'Hide comments') : t('post.showComments', 'Show comments')}
           >
             <MessageCircle className="h-4 w-4" />
           </Button>
@@ -259,6 +269,7 @@ export default function PostCard({ post, onPostUpdate, onPostDelete, onUsernameC
               "hover:bg-amber-50 hover:text-amber-600 transition-colors h-8 w-8",
               isSaved && "text-amber-600"
             )}
+            aria-label={isSaved ? t('post.unsave', 'Unsave post') : t('post.save', 'Save post')}
           >
             {isSaved ? (
               <BookmarkCheck className="h-4 w-4 fill-current" />
@@ -278,6 +289,7 @@ export default function PostCard({ post, onPostUpdate, onPostDelete, onUsernameC
                 size="icon"
                 onClick={() => setShowDeleteDialog(true)}
                 className="hover:bg-red-50 hover:text-red-600 transition-colors h-8 w-8"
+                aria-label={t('post.delete.button', 'Delete post')}
               >
                 <Trash2 className="h-4 w-4" />
               </Button>

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -79,6 +79,7 @@
         "title": "Your Profile",
         "description": "Manage your profile information",
         "username": "Username",
+        "userLabel": "User {{username}}",
         "biography": "Biography",
         "bioPlaceholder": "Tell us about yourself",
         "save": "Save",
@@ -268,6 +269,14 @@
     },
     "post": {
         "imageAlt": "{{username}}'s post image",
+        "imageDialogTitle": "{{username}}'s post image",
+        "imageDialogTitleGeneric": "Post image",
+        "closeImage": "Close image",
+        "like": "Like post",
+        "unlike": "Unlike post",
+        "save": "Save post",
+        "unsave": "Unsave post",
+        "showComments": "Show comments",
         "likes": "{{count}} like",
         "likes_plural": "{{count}} likes",
         "viewComments": "View {{count}} comment",
@@ -275,6 +284,7 @@
         "hideComments": "Hide comments",
         "edit": {
             "title": "Edit Post",
+            "button": "Edit post",
             "currentImage": "Current image will be kept unless you upload a new one",
             "newImage": "Upload New Image (Optional)",
             "save": "Save Changes",
@@ -282,6 +292,7 @@
         },
         "delete": {
             "title": "Delete Post",
+            "button": "Delete post",
             "description": "Are you sure you want to delete this post? This action cannot be undone.",
             "confirm": "Delete",
             "cancel": "Cancel",
@@ -298,8 +309,9 @@
         "placeholder": "Add a comment...",
         "save": "Save",
         "cancel": "Cancel",
-        "edit": "Edit",
-        "delete": {
+        "edit": "Edit comment",
+        "delete": "Delete comment",
+        "deleteDialog": {
             "title": "Delete Comment",
             "description": "Are you sure you want to delete this comment? This action cannot be undone.",
             "confirm": "Delete",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -79,6 +79,7 @@
         "title": "Profiliniz",
         "description": "Profil bilgilerinizi yönetin",
         "username": "Kullanıcı adı",
+        "userLabel": "Kullanıcı {{username}}",
         "biography": "Biyografi",
         "bioPlaceholder": "Kendinizden bahsedin",
         "save": "Kaydet",
@@ -264,11 +265,20 @@
     },
     "post": {
         "imageAlt": "{{username}}'in gönderi resmi",
+        "imageDialogTitle": "{{username}}'in gönderi resmi",
+        "imageDialogTitleGeneric": "Gönderi resmi",
+        "closeImage": "Resmi kapat",
+        "like": "Gönderiyi beğen",
+        "unlike": "Beğeniyi kaldır",
+        "save": "Gönderiyi kaydet",
+        "unsave": "Kaydedilenleri kaldır",
+        "showComments": "Yorumları göster",
         "likes": "{{count}} beğeni",
         "viewComments": "{{count}} yorumu görüntüle",
         "hideComments": "Yorumları gizle",
         "edit": {
             "title": "Gönderiyi Düzenle",
+            "button": "Gönderiyi düzenle",
             "currentImage": "Mevcut resim yeni bir resim yüklemediğiniz sürece korunacak",
             "newImage": "Yeni Resim Yükle (İsteğe Bağlı)",
             "save": "Değişiklikleri Kaydet",
@@ -276,6 +286,7 @@
         },
         "delete": {
             "title": "Gönderiyi Sil",
+            "button": "Gönderiyi sil",
             "description": "Bu gönderiyi silmek istediğinizden emin misiniz? Bu işlem geri alınamaz.",
             "confirm": "Sil",
             "cancel": "İptal",
@@ -292,8 +303,9 @@
         "placeholder": "Yorum ekle...",
         "save": "Kaydet",
         "cancel": "İptal",
-        "edit": "Düzenle",
-        "delete": {
+        "edit": "Yorumu düzenle",
+        "delete": "Yorumu sil",
+        "deleteDialog": {
             "title": "Yorumu Sil",
             "description": "Bu yorumu silmek istediğinizden emin misiniz? Bu işlem geri alınamaz.",
             "confirm": "Sil",


### PR DESCRIPTION
Add aria-labels to all icon buttons and interactive elements for improved screen reader compatibility throughout the frontend application.

Changes:
- Add aria-labels to post action buttons (like, comment, save)
- Add aria-labels to post edit/delete buttons
- Add aria-labels to comment edit/delete buttons
- Add aria-label to edit post dialog trigger
- Add aria-label to image dialog close button
- Change username buttons to divs with role='link' for better semantics
- Add proper keyboard navigation (Enter/Space) to username links

Translation updates:
- Add new aria-label keys to en.json (English)
- Add new aria-label keys to tr.json (Turkish)
- Update comment.delete structure to comment.deleteDialog

Screen reader improvements:
- Like button: announces 'Like post' or 'Unlike post'
- Comment button: announces 'Show comments' or 'Hide comments'
- Save button: announces 'Save post' or 'Unsave post'
- Edit button: announces 'Edit post' or 'Edit comment'
- Delete button: announces 'Delete post' or 'Delete comment'
- Username links: announce 'User <username> link' instead of 'button'

All buttons now properly announce their purpose to screen reader users, and username elements are semantically correct as links with full keyboard accessibility support.