### PR TITLE
fix/ fix no response when invalid credentials bug

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -91,10 +91,16 @@ export async function apiFetch<T>(endpoint: string, options: RequestInit = {}): 
     if (response.status === 401) {
       const method = (options.method || 'GET').toString().toUpperCase();
       const isDeleteAccount = method === 'DELETE' && endpoint.startsWith('/api/users/');
+      const isLogin = endpoint === '/api/sessions';
+      
       if (isDeleteAccount) {
         throw new Error('Incorrect password');
       }
 
+      // Don't redirect on login failures - just throw the error
+      if (isLogin) {
+        throw new Error(errorMessage);
+      }
       clearTokens();
       localStorage.removeItem('username');
       if (!window.location.pathname.startsWith('/auth')) {


### PR DESCRIPTION
The related bug is explained [here](https://github.com/bounswe/bounswe2025group5/issues/725). It is fixed now. I have added an extra check when the a 401 is returned. If it is losing endpoint, we throw an error with the message. @abdarslan Can you review?